### PR TITLE
cap06: correções ortográficas

### DIFF
--- a/capitulos/cap06.adoc
+++ b/capitulos/cap06.adoc
@@ -43,7 +43,7 @@ Vamos começar desaprendendo que uma variável é como uma caixa onde você guar
 
 Em 1997, ((("object references", "variables as labels versus boxes", id="ORvar06")))((("variables", "as labels versus boxes", secondary-sortas="labels versus boxes", id="Vlabel06"))) fiz um curso de verão sobre Java no MIT. A professora, Lynn Stein footnote:[Lynn Andrea Stein é uma aclamada educadora de ciências da computação. Ela
 https://fpy.li/6-1[atualmente leciona na Olin College of Engineering (EN)].]
-, apontou que a metáfora comum, de “variáveis como caixas”, na verdade atrapalha o entendimento de variáveis de referência em linguagens orientadas a objetos. As variáveis em Python são como variáveis de referência em Java; uma metáfora melhor é pensar em uma variável como um rótulo (ou etiqueta) que associa um nome a um objeto. O exemplo e a figura a seguir ajudam a entender o motivo disso.
+, apontou que a metáfora comum, de “variáveis como caixas”, na verdade, atrapalha o entendimento de variáveis de referência em linguagens orientadas a objetos. As variáveis em Python são como variáveis de referência em Java; uma metáfora melhor é pensar em uma variável como um rótulo (ou etiqueta) que associa um nome a um objeto. O exemplo e a figura a seguir ajudam a entender o motivo disso.
 
 <<ex_a_b_refs>> é uma interação simples que não pode ser explicada por “variáveis como caixas”.
 A <<var-boxes-x-labels>> ilustra o motivo de metáfora da caixa estar errada em Python, enquanto etiquetas apresentam uma imagem mais útil para entender como variáveis funcionam.
@@ -119,7 +119,7 @@ TypeError: unsupported operand type(s) for *: 'Gizmo' and 'int'
 
 [TIP]
 ====
-Para entender uma a atribuição em Python, leia primeiro o lado direito: é ali que o objeto é criado ou recuperado. Depois disso, a variável do lado esquerdo é vinculada ao objeto, como uma etiqueta colada a ele. Esqueça as caixas.
+Para entender uma atribuição em Python, leia primeiro o lado direito: é ali que o objeto é criado ou recuperado. Depois disso, a variável do lado esquerdo é vinculada ao objeto, como uma etiqueta colada a ele. Esqueça as caixas.
 ====
 
 Como variáveis são apenas meras etiquetas, nada impede que um objeto tenha várias etiquetas vinculadas a si. Quando isso acontece, você tem _apelidos_ (aliases), nosso próximo tópico.((("", startref="ORvar06")))((("", startref="Vlabel06")))
@@ -191,16 +191,16 @@ Na prática, nós raramente usamos a função `id()` quando programamos. A verif
 
 [TIP]
 ====
-Para o revisor técnico Leonardo Rochael, o uso mais frequente de `id()` ocorre durante o processo de debugging, quando o `repr()` de dois objetos são semelhantes, mas você precisa saber se duas referências são apelidos ou apontam para objetos diferentes. Se as referências estão em contextos diferentes - por exemplo em stack frames diferentes - pode não ser viável usar `is`.
+Para o revisor técnico Leonardo Rochael, o uso mais frequente de `id()` ocorre durante o processo de debugging, quando o `repr()` de dois objetos são semelhantes, mas você precisa saber se duas referências são apelidos ou apontam para objetos diferentes. Se as referências estão em contextos diferentes -- por exemplo, em stack frames diferentes -- pode não ser viável usar `is`.
 ====
 
 
 [[choosing_eq_v_is_sec]]
 ==== Escolhendo Entre == e is
 
-O operador ((("is operator"))) `==` compara os valores de objetos (os dados que eles cantém), enquanto `is` compara suas identidades.
+O operador ((("is operator"))) `==` compara os valores de objetos (os dados que eles contém), enquanto `is` compara suas identidades.
 
-Quando estamos programando, em geral nos preocupamos mais com os valores que com as identidades dos objetos, então `==` aparece com mais frequência que `is` em programas Python.
+Quando estamos programando, em geral, nos preocupamos mais com os valores que com as identidades dos objetos, então `==` aparece com mais frequência que `is` em programas Python.
 
 Entretanto, se você estiver comparando uma variável com um singleton (um objeto único) faz mais sentido usar `is`.
 O caso mais comum, de longe, é verificar se a variável está vinculada a `None`.
@@ -233,11 +233,11 @@ def traverse(...):
     # etc.
 ----
 
-O operador `is` é mais rápido que `==`, pois não pode ser sobrecarregado. Daí o Python não precisa encontrar e invocar métodos especiais para calcular seu resultado, e o processamento é tão simples quanto comparar dois IDs inteiros. Por outro lado, `a == b` é açúcar sintático para `+a.__eq__(b)+`. O método `+__eq__+`, herdado de `object`, compara os IDs dos objetos, então produz o mesmo resultado de `is`. Mas a maioria do tipos embutidos sobrepõe `+__eq__+` com implementações mais úteis, que  levam em consideração os valores dos atributos dos objetos. A determinação da igualdade pode envolver muito processamento--por exemplo, quando se comparam coleções grandes ou estruturas aninhadas com muitos níveis.
+O operador `is` é mais rápido que `==`, pois não pode ser sobrecarregado. Daí o Python não precisa encontrar e invocar métodos especiais para calcular seu resultado, e o processamento é tão simples quanto comparar dois IDs inteiros. Por outro lado, `a == b` é açúcar sintático para `+a.__eq__(b)+`. O método `+__eq__+`, herdado de `object`, compara os IDs dos objetos, então produz o mesmo resultado de `is`. Mas a maioria dos tipos embutidos sobrepõe `+__eq__+` com implementações mais úteis, que  levam em consideração os valores dos atributos dos objetos. A determinação da igualdade pode envolver muito processamento--por exemplo, quando se comparam coleções grandes ou estruturas aninhadas com muitos níveis.
 
 [WARNING]
 ====
-Normalmente estamos mais interessados na igualdade que na identidade de objetos. Checar se o objeto é `None` é _o único_ caso de uso comum do operador `is`. A maioria dos outros usos que eu vejo quando reviso código estão errados. Se você não estiver seguro, use `==`. Em geral é o que você quer, e ele também funciona com `None`, ainda que não tão rápido.
+Normalmente estamos mais interessados na igualdade que na identidade de objetos. Checar se o objeto é `None` é _o único_ caso de uso comum do operador `is`. A maioria dos outros usos que eu vejo quando reviso código estão errados. Se você não estiver seguro, use `==`. Em geral, é o que você quer, e ele também funciona com `None`, ainda que não tão rápido.
 ====
 
 Para concluir essa discussão de identidade versus igualdade, vamos ver como o tipo notoriamente imutável `tuple` não é assim tão invariável quanto você poderia supor.
@@ -246,11 +246,11 @@ Para concluir essa discussão de identidade versus igualdade, vamos ver como o t
 [[tuple-relative-immutable]]
 ==== A Imutabilidade Relativa das Tuplas
 
-As tuplas, como((("tuples", "relative immutability of"))) a maioria das coleções em Python -- lists, dicts, sets, etc..&#x2014; são containers: eles armazenam referências para objetos.footnote:[Ao contrário de sequências simples de tipo único, como `str`, `byte` e `array.array`, que não contêm referências e sim seu conteúdo --caracteres, bytes e números-- armazenado em um espaço contíguo de memória.]
+As tuplas, como((("tuples", "relative immutability of"))) a maioria das coleções em Python -- lists, dicts, sets, etc..&#x2014; são containers: eles armazenam referências para objetos.footnote:[Ao contrário de sequências simples de tipo único, como `str`, `byte` e `array.array`, que não contêm referências e sim seu conteúdo -- caracteres, bytes e números -- armazenado em um espaço contíguo de memória.]
 
-Se os itens referenciados forem mutáveis, eles poderão mudar, mesmo que tupla em si não mude. Em outras palavras, a imutabilidade das tuplas na verdade se refere ao conteúdo físico da estrutura de dados `tupla` (isto é, as referências que ela mantém), e não se estende aos objetos referenciados.
+Se os itens referenciados forem mutáveis, eles poderão mudar, mesmo que tupla em si não mude. Em outras palavras, a imutabilidade das tuplas, na verdade, se refere ao conteúdo físico da estrutura de dados `tupla` (isto é, as referências que ela mantém), e não se estende aos objetos referenciados.
 
-<<ex_mutable_tuples>> ilustra uma situação em que o valor de uma tupla muda como resultado de mudanças em um objeto mutável ali referenciado. O quê não pode nunca mudar em uma tupla é a identidade dos itens que ela contêm.
+<<ex_mutable_tuples>> ilustra uma situação em que o valor de uma tupla muda como resultado de mudanças em um objeto mutável ali referenciado. O quê não pode nunca mudar em uma tupla é a identidade dos itens que ela contém.
 
 [[ex_mutable_tuples]]
 .`t1` e `t2` inicialmente são iguais, mas a mudança em um item mutável dentro da tupla `t1` as torna diferentes
@@ -306,13 +306,13 @@ False
 
 Para listas e outras sequências mutáveis, o atalho `l2 = l1[:]` também cria uma cópia.
 
-Contudo, tanto o construtor quanto `[:]` produzem uma _cópia rasa_ (shallow copy). Isto é, o container externo é duplicado, mas a cópia é preeenchida com referências para os mesmos itens contidos no container original. Isso economiza memória  e não causa qualquer problema se todos os itens forem imutáveis. Mas se existirem itens mutáveis, isso pode gerar surpresas desagradáveis.
+Contudo, tanto o construtor quanto `[:]` produzem uma _cópia rasa_ (shallow copy). Isto é, o container externo é duplicado, mas a cópia é preenchida com referências para os mesmos itens contidos no container original. Isso economiza memória  e não causa qualquer problema se todos os itens forem imutáveis. Mas se existirem itens mutáveis, isso pode gerar surpresas desagradáveis.
 
 Em <<ex_shallow_copy>> criamos uma lista contendo outra lista e uma tupla, e então fazemos algumas mudanças para ver como isso afeta os objetos referenciados.
 
 [TIP]
 ====
-Se você tem um computador conectado à internet disponível, recomendo fortemente que você assista a animação interativa do <<ex_shallow_copy>> em https://fpy.li/6-3[Online Python Tutor]. No momento em que escrevo, o link direto para um exemplo pronto no _pythontutor.com_ não estava funcionando de forma estável.
+Se você tem um computador conectado à internet disponível, recomendo fortemente que você assista à animação interativa do <<ex_shallow_copy>> em https://fpy.li/6-3[Online Python Tutor]. No momento em que escrevo, o link direto para um exemplo pronto no _pythontutor.com_ não estava funcionando de forma estável.
 Mas a ferramenta é ótima, então vale a pena gastar seu tempo copiando e colando o código.
 ====
 
@@ -408,7 +408,7 @@ Agora, no <<ex_bus1_console>> interativo, vamos criar um objeto +bus+ (+bus1+) e
 <1> Usando `copy` e `deepcopy`, criamos três instâncias distintas de `Bus`.
 <2> Após `bus1` deixar `'Bill'`, ele também desaparece de `bus2`.
 <3> A inspeção do atributo dos `passengers` mostra que `bus1` e `bus2` compartilham o mesmo objeto lista, pois `bus2` é uma cópia rasa de `bus1`.
-<4> `bus3` é uma cópia profunda de `bus1`, então seu atributo `passengers`` se refere a outra lista.
+<4> `bus3` é uma cópia profunda de `bus1`, então seu atributo `passengers` se refere a outra lista.
 
 Observe que, em geral, criar cópias profundas não é uma questão simples. Objetos podem conter referências cíclicas que fariam um algorítmo ingênuo entrar em um loop infinito. A função 'deepcopy' lembra dos objetos já copiados, de forma a tratar referências cíclicas de modo elegante. Isso é demonstrado em  <<ex_cycle1>>.
 
@@ -431,12 +431,12 @@ Observe que, em geral, criar cópias profundas não é uma questão simples. Obj
 
 Além disso, algumas vezes uma cópia profunda pode ser profunda demais. Por exemplo, objetos podem ter referências para recursos externos ou para singletons (objetos únicos) que não devem ser copiados. Você pode controlar o comportamento de `copy` e de `deepcopy` implementando os métodos especiais `+__copy__+` e `+__deepcopy__+`, como descrito em https://docs.python.org/pt-br/3/library/copy.html [documentação do módulo `copy`]
 
-O compartilhamento de objetos através de apelidos também explica como a passagens de parâmetros funciona em Python, e o problema do uso de tipo mutáveis como parâmetros default. Vamos falar sobre essas questões a seguir.((("", startref="deepcopy06")))((("", startref="Cdeep06")))((("", startref="ORdeep06")))
+O compartilhamento de objetos através de apelidos também explica como a passagens de parâmetros funciona em Python, e o problema do uso de tipos mutáveis como parâmetros default. Vamos falar sobre essas questões a seguir.((("", startref="deepcopy06")))((("", startref="Cdeep06")))((("", startref="ORdeep06")))
 
 
 === Parâmetros de Função como Referências
 
-O((("object references", "function parameters as references", id="ORfparam06")))((("call by sharing")))((("parameters", "parameter passing"))) único modo de passagem de parâmetros em Python é a _chamada por compartilhamento_ (_call by sharing_). É o mesmo modo usado na maioria das linguagens orientadas a objetos, incluindo Javascript, Ruby e Java (em Java isso se aplica aos tipos de refêrencia; tipo primitivos usam a chamada por valor). Chamada por compartilhamento significa que cada parâmetro formal da função recebe uma cópia de cada referência nos argumentos. Em outras palavras, os parâmetros dentro da função se tornam apelidos dos argumentos.
+O((("object references", "function parameters as references", id="ORfparam06")))((("call by sharing")))((("parameters", "parameter passing"))) único modo de passagem de parâmetros em Python é a _chamada por compartilhamento_ (_call by sharing_). É o mesmo modo usado na maioria das linguagens orientadas a objetos, incluindo Javascript, Ruby e Java (em Java isso se aplica aos tipos de referência; tipos primitivos usam a chamada por valor). Chamada por compartilhamento significa que cada parâmetro formal da função recebe uma cópia de cada referência nos argumentos. Em outras palavras, os parâmetros dentro da função se tornam apelidos dos argumentos.
 
 O resultado desse esquema é que a função pode modificar qualquer objeto mutável passado a ela como parâmetro, mas não pode mudar a identidade daqueles objetos (isto é, ela não pode substituir integralmente um objeto por outro).
 <<ex_param_pass>> mostra uma função simples usando `+=` com um de seus parâmetros. Quando passamos números, listas e tuplas para a função, os argumentos originais são afetados de maneiras diferentes.
@@ -535,7 +535,7 @@ True
 <1> `bus1` começa com uma lista de dois passageiros.
 <2> Até aqui, tudo bem: nenhuma surpresa em `bus1`.
 <3> `bus2` começa vazio, então a lista vazia default é vinculada a `self.passengers`.
-<4> `bus3` também começa vazio, e novamente a lista default é atribuida. 
+<4> `bus3` também começa vazio, e novamente a lista default é atribuída.
 <5> A lista default não está mais vazia!
 <6> Agora `Dave`, pego pelo `bus3`, aparece no `bus2`.
 <7> O problema: `bus2.passengers` e `bus3.passengers` se referem à mesma lista.
@@ -543,7 +543,7 @@ True
 
 O problema é que instâncias de `HauntedBus` que não recebem uma lista de passageiros inicial acabam todas compartilhando a mesma lista de passageiros entre si.
 
-Este tipo de bug pode ser muito sutil. Como <<demo_haunted_bus>> demonstra, quando `HauntedBus`` recebe uma lista com passageiros como parâmetro, ele funciona como esperado. As coisas estranhas acontecem somente quando `HauntedBus` começa vazio, pois aí `self.passengers` se torna um apelido para o valor default do parâmetro `passengers`. O problema é que cada valor default é processado quando a função é definida -- i.e., normalmente quando o módulo é carregado-- e os valores default se tornam atributos do objeto-função. Assim, se o valor default é um objeto [.keep-together]#mutável# e você o altera, a alteração vai afetar todas as futuras chamadas da [.keep-together]#função#.
+Este tipo de bug pode ser muito sutil. Como <<demo_haunted_bus>> demonstra, quando `HauntedBus` recebe uma lista com passageiros como parâmetro, ele funciona como esperado. As coisas estranhas acontecem somente quando `HauntedBus` começa vazio, pois aí `self.passengers` se torna um apelido para o valor default do parâmetro `passengers`. O problema é que cada valor default é processado quando a função é definida -- i.e., normalmente quando o módulo é carregado -- e os valores default se tornam atributos do objeto-função. Assim, se o valor default é um objeto [.keep-together]#mutável# e você o altera, a alteração vai afetar todas as futuras chamadas da [.keep-together]#função#.
 
 Após executar as linhas do exemplo em <<demo_haunted_bus>>, você pode inspecionar o objeto `HauntedBus__init__` e ver os estudantes fantasma assombrando o atributo `+__defaults__+`:
 
@@ -572,7 +572,7 @@ A próxima seção explica porque copiar o argumento é uma boa prática.
 
 Ao escrever uma função que recebe um parâmetro mutável, você deve considerar com cuidado se o cliente que chama sua função espera que o argumento passado seja modificado.
 
-Por exemplo, se sua função recebe um `dict` e precisa modificá-lo duranto seu processamento, esse efeito colateral deve ou não ser visível fora da função? A resposta, na verdade, depende do contexto. É tudo uma questão de alinhar as expectativas do autor da função com as do cliente da função. 
+Por exemplo, se sua função recebe um `dict` e precisa modificá-lo durante seu processamento, esse efeito colateral deve ou não ser visível fora da função? A resposta, na verdade, depende do contexto. É tudo uma questão de alinhar as expectativas do autor da função com as do cliente da função.
 
 O último exemplo com ônibus neste capítulo mostra como um `TwilightBus` rompe as expectativas ao compartilhar sua lista de passageiros com seus clientes. Antes de estudar a implementação, veja como a classe `TwilightBus` funciona da perspectiva de um cliente daquela classe, em <<demo_twilight_bus>>.
 
@@ -610,7 +610,7 @@ include::code/06-obj-ref/twilight_bus.py[tags=TWILIGHT_BUS_CLASS]
 [role="pagebreak-before less_space"]
 <1> Aqui nós cuidadosamente criamos uma lista vazia quando `passengers` é `None`.
 <2> Entretanto, esta atribuição transforma `self.passengers` em um apelido para `passengers`, que por sua vez é um apelido para o argumento efetivamente passado para `+__init__+` (i.e. `basketball_team` em <<demo_twilight_bus>>).
-<3> Quando os métodos `.remove()` e `.append()` são usados com `self.passengers`, estamos na verdade modificando a lista original recebida como argumento pelo construtor.
+<3> Quando os métodos `.remove()` e `.append()` são usados com `self.passengers`, estamos, na verdade, modificando a lista original recebida como argumento pelo construtor.
 
 O problema aqui é que o ônibus está apelidando a lista passada para o construtor. Ao invés disso, ele deveria manter sua própria lista de passageiros. A solução é simples: em `+__init__+`, quando o parâmetro `passengers` é fornecido, `self.passengers` deveria ser inicializado com uma cópia daquela lista, como fizemos, de forma correta, em <<ex_bus1>>:
 
@@ -644,9 +644,9 @@ ____
 
 A((("del statement", id="del06"))) primeira estranheza sobre `del` é ele não ser uma função, mas um comando.
 
-Escrevemos `del x` e não `del(x)` - apesar dessa última forma funcionar também, mas apenas porque as expressões `x` e `(x)` em geral terem o mesmo significado em Python.
+Escrevemos `del x` e não `del(x)` -- apesar dessa última forma funcionar também, mas apenas porque as expressões `x` e `(x)` em geral terem o mesmo significado em Python.
 
-O segundo aspecto surpreeendente é que `del` apaga referências, não objetos. A coleta de lixo pode eliminar um objeto da memória como resultado indireto de `del`, se a variável apagada for a última referência ao objeto. Reassociar uma variável também pode reduzir a zero o número de referências a um objeto, causando sua destruição.
+O segundo aspecto surpreendente é que `del` apaga referências, não objetos. A coleta de lixo pode eliminar um objeto da memória como resultado indireto de `del`, se a variável apagada for a última referência ao objeto. Reassociar uma variável também pode reduzir a zero o número de referências a um objeto, causando sua destruição.
 
 [source, pycon]
 ----
@@ -714,7 +714,7 @@ False
 
 O ponto principal de <<ex_finalize>> é mostrar explicitamente que `del` não apaga objetos, mas que objetos podem ser apagados como uma consequência de se tornarem inacessíveis após o uso de `del`.
 
-Você pode estar se perguntando porque o objeto `{1, 2, 3}` foi destruído em <<ex_finalize>>. Afinal, a referência `s1` foi passada para a função `finalize`, que precisa tê-la mantido para conseguir monitorar o objeto e invocar o callback. Isso funciona porque `finalize` mantém uma((("weak references"))) _referência fraca_ (_weak reference_) para {1, 2, 3}. Referências fracas não aumentam a contagem de referências de um objeto. Assim, uma referência fraca não evita que o objeto alvo seja destruido pelo coletor de lixo. Referências fracas são úteis em cenários de caching, pois não queremos que os objetos "cacheados" sejam mantidos vivos apenas por terem uma referência no cache.((("", startref="ORdel06")))((("", startref="del06")))((("", startref="garb06")))
+Você pode estar se perguntando porque o objeto `{1, 2, 3}` foi destruído em <<ex_finalize>>. Afinal, a referência `s1` foi passada para a função `finalize`, que precisa tê-la mantido para conseguir monitorar o objeto e invocar o callback. Isso funciona porque `finalize` mantém uma((("weak references"))) _referência fraca_ (_weak reference_) para {1, 2, 3}. Referências fracas não aumentam a contagem de referências de um objeto. Assim, uma referência fraca não evita que o objeto alvo seja destruído pelo coletor de lixo. Referências fracas são úteis em cenários de caching, pois não queremos que os objetos "cacheados" sejam mantidos vivos apenas por terem uma referência no cache.((("", startref="ORdel06")))((("", startref="del06")))((("", startref="garb06")))
 
 [NOTE]
 ====
@@ -726,7 +726,7 @@ https://fpy.li/weakref["Weak References" em _fluentpython.com_].
 
 [NOTE]
 ====
-Está((("object references", "immutability and"))) seção opcional discute alguns detalhes que na verdade não são muito importantes para _usuários_ de Python, e que podem não se aplicar a outras implementações da linguagem ou mesmo a futuras versões de CPython. Entretanto, já vi muita gente tropeçar nesses casos laterais e daí passar a usar o((("is operator"))) operador `is` de forma incorreta, então acho que vale a pena mencionar esses detalhes.
+Está((("object references", "immutability and"))) seção opcional discute alguns detalhes que, na verdade, não são muito importantes para _usuários_ de Python, e que podem não se aplicar a outras implementações da linguagem ou mesmo a futuras versões de CPython. Entretanto, já vi muita gente tropeçar nesses casos laterais e daí passar a usar o((("is operator"))) operador `is` de forma incorreta, então acho que vale a pena mencionar esses detalhes.
 ====
 
 Eu((("tuples", "immutability and"))) fiquei surpreso em descobrir que, para uma tupla `t`, a chamada `t[:]` não cria uma cópia, mas devolve uma referência para o mesmo objeto. Da mesma forma, `tuple(t)` também retorna uma referência para a mesma tupla.footnote:[Isso está claramente documentado. Digite `help(tuple)` no console do Python e leia: "Se o argumento é uma tupla, o valor de retorno é o mesmo objeto." Pensei que sabia tudo sobre tuplas antes de escrever esse livro.]
@@ -787,7 +787,7 @@ Os truques discutidos nessa seção, incluindo o comportamento de `frozenset.cop
 
 Todo((("object references", "overview of"))) objeto em Python tem uma identidade, um tipo e um valor. Apenas o valor do objeto pode mudar ao longo do tempo.footnote:[Na verdade, o tipo de um objeto pode ser modificado, bastando para isso atribuir uma classe diferente ao atributo `+__class__+` do objeto. Mas isso é uma perversão, e eu me arrependo de ter escrito essa nota de rodapé.]
 
-Se duas variáveis se referem a objetos imutáveis de igual valor (`a == b` is `True`), na prática dificilmente importa se elas se referem a cópias de mesmo valor ou são apelidos do mesmo objeto, porque o valor de objeto imutável não muda, com uma exceção. A exceção são as coleções imutáveis, como as tuplas: se uma coleção imutável contém referências para itens mutáveis, então seu valor pode de fato mudar quando o valor de um item mutável for modificado. Na prática, esse cenário não é tão comum. O que nunca muda numa coleção imutável são as identidades dos objetos mantidos ali. A classe `frozenset` não sofre desse problema, porque ela só pode manter elementos hashable, e o valor de um objeto hashble não pode mudar nunca, por [.keep-together]#definição#.
+Se duas variáveis se referem a objetos imutáveis de igual valor (`a == b` is `True`), na prática, dificilmente importa se elas se referem a cópias de mesmo valor ou são apelidos do mesmo objeto, porque o valor de objeto imutável não muda, com uma exceção. A exceção são as coleções imutáveis, como as tuplas: se uma coleção imutável contém referências para itens mutáveis, então seu valor pode de fato mudar quando o valor de um item mutável for modificado. Na prática, esse cenário não é tão comum. O que nunca muda numa coleção imutável são as identidades dos objetos mantidos ali. A classe `frozenset` não sofre desse problema, porque ela só pode manter elementos hashable, e o valor de um objeto hashable não pode mudar nunca, por [.keep-together]#definição#.
 
 O fato de variáveis manterem referências tem muitas consequências práticas para a programação em Python:
 
@@ -801,7 +801,7 @@ O fato de variáveis manterem referências tem muitas consequências práticas p
 
 Em CPython, os objetos são descartados assim que o número de referências a eles chega a zero. Eles também podem ser descartados se formarem grupos com referências cíclicas sem nenhuma referência externa ao grupo.
 
-Em algumas situações, pode ser útil manter uma referência para um objeto que não irá --por si só-- manter o objeto vivo. Um exemplo é uma classe que queira manter o registro de todas as suas instâncias atuais. Isso pode ser feito com referências fracas, um mecanismo de baixo nível encontrado nas úteis coleções `WeakValueDictionary`, `WeakKeyDictionary`, `WeakSet`, e na função `finalize` do módulo `weakref`.
+Em algumas situações, pode ser útil manter uma referência para um objeto que não irá -- por si só -- manter o objeto vivo. Um exemplo é uma classe que queira manter o registro de todas as suas instâncias atuais. Isso pode ser feito com referências fracas, um mecanismo de baixo nível encontrado nas úteis coleções `WeakValueDictionary`, `WeakKeyDictionary`, `WeakSet`, e na função `finalize` do módulo `weakref`.
 
 Para saber mais, leia https://fpy.li/weakref["Weak References" em _fluentpython.com_].
 
@@ -815,11 +815,11 @@ Wesley Chun, autor da série _Core Python_, apresentou https://fpy.li/6-8[Unders
 Doug Hellmann escreveu os posts https://fpy.li/6-9["copy – Duplicate Objects"] (EN) e
 https://fpy.li/6-10["weakref&mdash;Garbage-Collectable References to Objects"] (EN), cobrindo alguns dos tópicos que acabamos de tratar.
 
-Você pode encontrar mais informações sobre o coletor de lixo geracional do CPython em the https://docs.python.org/pt-br/3/library/gc.html[gc — Interface para o coletor de lixo¶], que começa com a frase "Este módulo fornece uma interface para o opcional garbage collector". O adjetivo "opcional" usado aqui pode ser surpreeendente, mas o https://docs.python.org/pt-br/3/reference/datamodel.html[capítulo "Modelo de Dados"] também afirma:
+Você pode encontrar mais informações sobre o coletor de lixo geracional do CPython em the https://docs.python.org/pt-br/3/library/gc.html[gc — Interface para o coletor de lixo¶], que começa com a frase "Este módulo fornece uma interface para o opcional garbage collector". O adjetivo "opcional" usado aqui pode ser surpreendente, mas o https://docs.python.org/pt-br/3/reference/datamodel.html[capítulo "Modelo de Dados"] também afirma:
 
 [quote]
 ____
-Uma implementação tem permissão para adiar a coleta de lixo ou omiti-la completamente – é uma questão de detalhe de implementação como a coleta de lixo é implementada, desde que nenhum objeto que ainda esteja acessível seja coletado.
+Uma implementação tem permissão para adiar a coleta de lixo ou omiti-la completamente -- é uma questão de detalhe de implementação como a coleta de lixo é implementada, desde que nenhum objeto que ainda esteja acessível seja coletado.
 ____
 
 [role="pagebreak-before less_space"]
@@ -855,22 +855,22 @@ Este((("Soapbox sidebars", "mutability")))((("mutable objects")))((("objects", "
 
 Se `a == b` é verdade, e nenhum dos dois objetos pode mudar, eles podem perfeitamente ser o mesmo objeto. Por isso a internalização de strings é segura. A identidade dos objetos ser torna importante apenas quando esses objetos podem mudar.
 
-Em programação funcional "pura", todos os dados são imutáveis: concatenar algo a uma coleção na verdade cria uma nova coleção.
-Elixir é um linguagem funcional prática e fácil de aprender, na qual todos os tipo nativos são imutáveis, incluindo as listas.
+Em programação funcional "pura", todos os dados são imutáveis: concatenar algo a uma coleção, na verdade, cria uma nova coleção.
+Elixir é uma linguagem funcional prática e fácil de aprender, na qual todos os tipos nativos são imutáveis, incluindo as listas.
 
-Python, por outro lado, não é uma linguagem funcional, menos uma ainda uma linguagem pura. Instâncias de classes definidas pelo usuário são mutáveis por default em Python --como na maioria das liguagens orientadas a objetos. Ao criar seus próprios objetos, você tem que tomar o cuidado adicional de torná-los imutáveis, se este for um requisito. Cada atributo do objeto precisa ser também imutável, senão você termina criando algo como uma tupla: imutável quanto ao ID do objeto, mas seu valor pode mudar se a tupla contiver um objeto mutável. 
+Python, por outro lado, não é uma linguagem funcional, menos uma ainda uma linguagem pura. Instâncias de classes definidas pelo usuário são mutáveis por default em Python -- como na maioria das linguagens orientadas a objetos. Ao criar seus próprios objetos, você tem que tomar o cuidado adicional de torná-los imutáveis, se este for um requisito. Cada atributo do objeto precisa ser também imutável, senão você termina criando algo como uma tupla: imutável quanto ao ID do objeto, mas seu valor pode mudar se a tupla contiver um objeto mutável.
 
 Objetos mutáveis também são a razão pela qual programar com threads é tão difícil: threads modificando objetos sem uma sincronização apropriada podem corromper dados. Sincronização excessiva, por outro lado, causa deadlocks. 
-A linguagem e a plataforma Erlang --que inclui Elixir-- foi projetada para maximizar o tempo de execução em aplicações distribuídas de alta concorrência, tais como aplicações de controle de telecomunicações. Naturalemente, eles escolheram tornar os dados imutáveis por default.
+A linguagem e a plataforma Erlang -- que inclui Elixir -- foi projetada para maximizar o tempo de execução em aplicações distribuídas de alta concorrência, tais como aplicações de controle de telecomunicações. Naturalmente, eles escolheram tornar os dados imutáveis por default.
 
 [role="soapbox-title"]
 Destruição de Objetos e Coleta de Lixo
 
-Não há((("Soapbox sidebars", "object destruction and garbage collection")))((("garbage collection"))) qualquer mecanismo em Python para destruir um objeto diretamente, e essa omissão é na verdade uma grande qualidade: se você pudesse destruir um objeto a qualquer momento, o que aconteceria com as referências que apontam para ele?
+Não há((("Soapbox sidebars", "object destruction and garbage collection")))((("garbage collection"))) qualquer mecanismo em Python para destruir um objeto diretamente, e essa omissão é, na verdade, uma grande qualidade: se você pudesse destruir um objeto a qualquer momento, o que aconteceria com as referências que apontam para ele?
 
 A coleta de lixo em CPython é feita principalmente por contagem de referências, que é fácil de implementar, mas vulnerável a vazamentos de memória (_memory leaks_) quando existem referências cíclicas. Assim, com a versão 2.0 (de outubro de 2000), um coletor de lixo geracional foi implementado, e ele consegue dispor de objetos inatingíveis que foram mantidos vivos por ciclos de referências.
 
-Mas a contagem de referências ainda está lá como mecanismo básico, e ela causa a destruição imediata de objetos com zero referências. Isso significa que, em CPython --pelo menos por hora-- é seguro escrever:
+Mas a contagem de referências ainda está lá como mecanismo básico, e ela causa a destruição imediata de objetos com zero referências. Isso significa que, em CPython -- pelo menos por hora -- é seguro escrever:
 
 [source, python3]
 ----
@@ -890,6 +890,6 @@ Se você estiver interessado no assunto de coletores de lixo, você talvez queir
 [role="soapbox-title"]
 Passagem de Parâmetros: Chamada por Compartilhamento
 
-Um maneira popular de explicar como a passagem de parâmetros funciona em Python é a frase: "Parâmetros são passados por valor, mas os valores são referências." Isso não está errado, mas causa confusão porque os modos mais comuns de passagem de parâmetros nas linguagens antigas são _chamada por valor_ (a função recebe uma cópia dos argumentos) e _chamada por referência_ (a função recebe um ponteiro para o argumento). Em Python, a função recebe uma cópia dos argumentos, mas os argumentos são sempre referências. Então o valor dos objetos referenciados podem ser alterados pela função, se eles forem mutáveis, mas sua identidade não. Além disso, como a funcão recebe uma cópia da referência em um argumento, reassociar essa referência no corpo da função não tem qualquer efeito fora da função. Adotei o termo _chamada por compartilhamento_ depois de ler sobre esse assunto em _Programming Language Pragmatics_, 3rd ed., de Michael L. Scott (Morgan Kaufmann), section "8.3.1: Parameter Modes."
+Uma maneira popular de explicar como a passagem de parâmetros funciona em Python é a frase: "Parâmetros são passados por valor, mas os valores são referências." Isso não está errado, mas causa confusão porque os modos mais comuns de passagem de parâmetros nas linguagens antigas são _chamada por valor_ (a função recebe uma cópia dos argumentos) e _chamada por referência_ (a função recebe um ponteiro para o argumento). Em Python, a função recebe uma cópia dos argumentos, mas os argumentos são sempre referências. Então o valor dos objetos referenciados podem ser alterados pela função, se eles forem mutáveis, mas sua identidade não. Além disso, como a função recebe uma cópia da referência em um argumento, reassociar essa referência no corpo da função não tem qualquer efeito fora da função. Adotei o termo _chamada por compartilhamento_ depois de ler sobre esse assunto em _Programming Language Pragmatics_, 3rd ed., de Michael L. Scott (Morgan Kaufmann), section "8.3.1: Parameter Modes."
 
 ****


### PR DESCRIPTION
Corrige erros de escrita, falta de vírgulas, má formatação de travessões no capítulo 6.

A maioria dos erros foram corrigidos com base no corretor ortográfico da IDE IntelliJ. Eles foram examinados um a um por mim (não fiz uma correção geral do arquivo sem olhar os erros individuais).

**Sobre os travessões**: Em arquivos AsciiDoc ` -- ` é convertido automaticamente no _em dash_ (`—`) somente se tiver entre dois espaços ou dois caracteres. O problema em algumas partes do texto é que as vezes `--` era colocado junto a uma palavra do lado esquerdo e com espaço no lado direito (ou vice versa).

**Possível mudança de estilo de escrita**: Todas as aparições de `na verdade` no texto eu coloquei entre vírgulas, como o corretor sugeria. Não sei o quanto esta regra é universal e tive receio de estar alterando algum estilo intencional no texto. Se for o caso, posso desfazer.

Obs.: Tudo bem criar PRs assim sem issues associadas?

Obs. 2: Na verdade, de acordo com a [documentação do AsciiDoc](https://docs.asciidoctor.org/asciidoc/latest/subs/replacements/#char-ref-sidebar)  `a -- b` e `a--b` são renderizados de maneira levemente diferente: na primeira opção se acrescenta "espaços finos" (`&#8201;`) e na segunda, não. Posso criar uma issue para padronizar isso, imagino que você prefira sem nenhum espaço.