### PR TITLE
Cria gh action workflow para automatizar da geração de um arquivo epub

### DIFF
--- a/.github/workflows/ebook.yaml
+++ b/.github/workflows/ebook.yaml
@@ -1,0 +1,33 @@
+name: Generate epub
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  Generate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0
+
+      - name: Install Asciidoctor EPUB3
+        run: gem install asciidoctor-epub3
+
+      - name: Generate EPUB from AsciiDoc
+        run: |
+          asciidoctor-epub3 livro.adoc -o 'Python Fluente, Segunda Edição (2023).epub'
+
+      - name: Save EPUB to Repository
+        run: |
+          git config user.name '${{ secrets.GIT_USER_NAME }}'
+          git config user.email '${{ secrets.GIT_USER_EMAIL }}'
+          git add 'Python Fluente, Segunda Edição (2023).epub'
+          git commit -m 'Gerando nova versão do epub'
+          git push origin


### PR DESCRIPTION
Pensando em resolver a issue https://github.com/pythonfluente/pythonfluente2e/issues/9 que eu havia criado em outro momento, esse PR é uma proposta para automatizar a geração da versão `.epub` a partir da versão mais atual do `.adoc`.

Para funcionamento do gh actions é preciso configurar nos _secrets_ o user.name e o user.email com permissão de escrita para realizar o commit do arquivo `.epub` no repositório.

O arquivo `epub` foi testado e funciona perfeitamente no Kindle (e provavelmente com outros e-readers que aceitem o formato). O sumário está automático e linkado para os capítulos. Ficou faltando apenas uma capa para o livro, porém, segundo [este tópico](https://docs.asciidoctor.org/epub3-converter/latest/#adding-the-cover-image) da documentação, basta adicionar o seguinte parâmetro ao livro:

```adoc
:front-cover-image: image:cover.png[Front Cover,1050,1600]
```

> PS: Coloquei o nome do arquivo epub para `'Python Fluente, Segunda Edição (2023).epub'` por conta do Kindle ler o nome do arquivo e definir como o nome do livro de fato. Nos meus testes, eu criei um `livro.epub` e o Kindle entendeu que o título era apenas livro.