### PR TITLE
Torna carregamento de imagens "lazy" com extensão do asciidoctor (extensão asciidoctor)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e  # exit when any command fails
-asciidoctor livro.adoc -o index.html
+asciidoctor -r ./ferramentas/addLazyLoadingImages.rb livro.adoc -o index.html
 open index.html

--- a/ferramentas/addLazyLoadingImages.rb
+++ b/ferramentas/addLazyLoadingImages.rb
@@ -1,0 +1,19 @@
+include Asciidoctor
+
+class AddLazyLoadingImages < Asciidoctor::Extensions::Postprocessor
+  def process document, output
+    if document.basebackend? 'html'
+      replacement = %(<img loading="lazy" \\1>)
+      output = output.gsub(/<img(.*?)>/m, replacement)
+    end
+    output
+  end
+end
+
+Asciidoctor::Extensions.register do
+  postprocessor AddLazyLoadingImages
+end
+
+Asciidoctor.convert_file 'livro.adoc', safe: :safe
+
+

--- a/livro.adoc
+++ b/livro.adoc
@@ -7,7 +7,6 @@ include::atributos-pt_BR.adoc[]
 :xrefstyle: short
 :sectnums:
 :sectlinks:
-:data-uri:
 :toc:
 :toclevels: 2
 :!chapter-signifier:


### PR DESCRIPTION
Relacionado a issue #1:
Cria [extensão de pós-processamento](https://docs.asciidoctor.org/asciidoctor/latest/extensions/postprocessor/) do asciidoctor que, por meio de regex, adiciona a string `loading="lazy"` a cada tag `<img>`  logo após a geração do arquivo HTML.

A extensão é adicionado junto ao comando de geração do arquivo HTML em `build.sh`.

Para que o _lazy loading_ funcione é necessário que as imagens tenham suas origens definidas por links/caminhos. Logo o atributo global `:data:uri:` teve que ser removido do arquivo `livro.adoc`.

Vale notar que eu não tive experiência com a linguagem ruby anteriormente. Aprendi o básico da linguagem no [rápido tutorial oficial da linguagem](https://www.ruby-lang.org/en/documentation/quickstart/) e em outras fontes.