### PR TITLE
torna carregamento de imagens "lazy" com regex (comando sed)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -e  # exit when any command fails
 asciidoctor livro.adoc -o index.html
+sed -i -e 's/<img/& loading="lazy" /g' index.html # add lazy loading to images
 open index.html

--- a/livro.adoc
+++ b/livro.adoc
@@ -7,7 +7,6 @@ include::atributos-pt_BR.adoc[]
 :xrefstyle: short
 :sectnums:
 :sectlinks:
-:data-uri:
 :toc:
 :toclevels: 2
 :!chapter-signifier:


### PR DESCRIPTION
Relacionado a issue #1:
Isto é feito utilizando o comando "sed" com regex no arquivo `build.sh` para adicionar a string 'loading="lazy"' nos atributos de cada elemento "img" no arquivo final HTML.

Para que o _lazy loading_ funcione é necessário que as imagens tenham suas origens definidas por links/caminhos. Logo o atributo global `:data:uri:` teve que ser removido do arquivo `livro.adoc`.
