### PR TITLE
Cap 01: Formatação Indesejada

### DIFF
--- a/capitulos/cap01.adoc
+++ b/capitulos/cap01.adoc
@@ -559,10 +559,10 @@ Aqui os nomes mais recentes são `+__matmul__+`, `+__rmatmul__+`, e `+__imatmul_
 |=====================================================================================================================================================================================
 |Categoria do operador|Símbolos|Nomes de métodos
 |Unário numérico| `-  +  abs()` | `+__neg__  __pos__  __abs__+`
-|Comparação rica| `<  <=  ==  !=  >  >=` | `+__lt__  __le__  __eq__  __ne__  __gt__  __ge__+`
+|Comparação rica| `<  \<=  ==  !=  >  >=` | `+__lt__  __le__  __eq__  __ne__  __gt__  __ge__+`
 |Aritmético| `+  -  *  /  //  %  @  divmod()  round()  **  pow()` | `+__add__  __sub__  __mul__+` pass:[<span class="keep-together"><code> __truediv__  </code></span>]  `+__floordiv__  __mod__+` pass:[<span class="keep-together"><code> __matmul__  </code></span>]  `+__divmod__  __round__  __pow__+`
 |Aritmética reversa| operadores aritméticos com operandos invertidos) |`+__radd__  __rsub__  __rmul__  __rtruediv__  __rfloordiv__  __rmod__  __rmatmul__  __rdivmod__  __rpow__+`
-|Atribuição aritmética aumentada| `+=  -=  *=  /=  //=  %=  @=  **=` | `+__iadd__  __isub__  __imul__  __itruediv__  __ifloordiv__  __imod__  __imatmul__  __ipow__+`
+|Atribuição aritmética aumentada| `+=  -=  \*=  /=  //=  %=  @=  **=` | `+__iadd__  __isub__  __imul__  __itruediv__  __ifloordiv__  __imod__  __imatmul__  __ipow__+`
 |Bit a bit         | `&  \|  ^  <<  >>  ~` | `+__and__  __or__  __xor__  __lshift__  __rshift__  __invert__+`
 |Bit a bit reversa| (operadores bit a bit com os operandos invertidos) | `+__rand__  __ror__  __rxor__  __rlshift__  __rrshift__+`
 |Atribuição bit a bit aumentada|  `&=  \|=  ^=  <<=  >>=` | `+__iand__  __ior__  __ixor__  __ilshift__  __irshift__+`
@@ -662,7 +662,7 @@ Mas não há como fazer a notação `[]` funcionar com um novo tipo de coleção
 Pior ainda, o Go não tem o conceito de uma interface iterável ou um objeto iterador ao nível do usuário, daí sua sintaxe para `for/range` estar limitada a suportar cinco tipos "mágicos" embutidos, incluindo arrays, strings e mapas.
 
 Talvez, no futuro, os projetistas do Go melhorem seu protocolo de metaobjetos.
-Em 2021, ele ainda é muito mais limitado do Python, Ruby, e JavaScript oferecem.
+Em 2021, ele ainda é muito mais limitado do que Python, Ruby, e JavaScript oferecem.
 
 
 [role="soapbox-title"]


### PR DESCRIPTION
Por conta da sintaxe de formatação, os operadores `<=` e `*=` estão sendo renderizados incorretamente na Tabela 2, capítulo 1.

### Atual

<img width="981" alt="image" src="https://github.com/pythonfluente/pythonfluente2e/assets/26190371/4816e525-1b16-43d3-8c5b-1b6a23a426da">
<img width="984" alt="image" src="https://github.com/pythonfluente/pythonfluente2e/assets/26190371/6511c673-bc42-4ca0-b693-f4809e36607c">

### Esperado

<img width="984" alt="image" src="https://github.com/pythonfluente/pythonfluente2e/assets/26190371/216381c0-dd43-4244-bf4e-45dc9c315cb0">
<img width="983" alt="image" src="https://github.com/pythonfluente/pythonfluente2e/assets/26190371/39d04eaf-2d59-4b12-ab1d-4162ded370c3">


#### Navegadores testados:
- Safari
- Chrome
- Brave

