### PR TITLE
Corrige pequeno typo em 2.10: `presenta` -> `presente`

### DIFF
--- a/capitulos/cap02.adoc
+++ b/capitulos/cap02.adoc
@@ -1653,7 +1653,7 @@ Por outro lado, se você está constantemente acrescentando e removendo itens da
 
 [TIP]
 ====
-Se seu código frequentemente verifica se um item está presenta em uma coleção (por exemplo, `item in my_collection`),
+Se seu código frequentemente verifica se um item está presente em uma coleção (por exemplo, `item in my_collection`),
 considere usar um `set` para `my_collection`, especialmente se ela contiver um número grande de itens.
 Um `set` é otimizado para verificação rápida de presença de itens.
 Eles também são iteráveis, mas não são coleções, porque a ordenação de itens de sets não é especificada.


### PR DESCRIPTION
Opa gente,
esse pequeno PR corrige um pequeno typo em 2.10: `presenta` -> `presente`.
Agradeço pelo trabalho, galera!