### PR TITLE
Correção de formatação nos capítulos 2 e 3

### DIFF
--- a/capitulos/cap02.adoc
+++ b/capitulos/cap02.adoc
@@ -1245,7 +1245,7 @@ Veja como isso torna legível o loop `for` no final do exemplo.
 ====
 
 Voltaremos aos objetos +slice+ quando formos discutir a criação de suas próprias coleções, na seção <<sliceable_sequence>>.
-Enquanto isso, do ponto de vista do usuário, o fatiamento tem recursos adicionais, tais como fatias multidimensionais e a notação de reticências (`...`).
+Enquanto isso, do ponto de vista do usuário, o fatiamento tem recursos adicionais, tais como fatias multidimensionais e a notação de reticências (`\...`).
 Siga comigo.
 
 
@@ -1260,9 +1260,9 @@ podem ser recuperados usando a sintaxe `a[i, j]`, e uma fatia bi-dimensional é 
 
 Exceto por `memoryview`, os tipos embutidos de sequência do Python são uni-dimensionais, então aceitam apenas um índice ou fatia, e não uma tupla de índices ou fatias.footnote:[Na seção <<memoryview_sec>> vamos mostrar que views da memória construídas de forma especial podem ter mais de uma dimensão.]
 
-As((("ellipsis (&#x2026;)")))((("&#x2026; (ellipsis)"))) reticências—escritas como três pontos finais (`...`) e não como `…` (Unicode U+2026)&#x2014;são reconhecidas como um símbolo pelo parser do Python. Esse símbolo é um apelido para o objeto `Ellipsis`, a única instância da classe `ellipsis`.footnote:[Não, eu não escrevi ao contrário: o nome da classe `ellipsis` realmente se escreve só com minúsculas, e a instância é um objeto embutido chamado `Ellipsis`, da mesma forma que `bool` é em minúsculas mas suas instâncias são `True` e `False`.]
-Dessa forma, ele pode ser passado como argumento para funções e como parte da especificação de uma fatia, como em `f(a, ..., z)` ou `a[i:...]`.
-O NumPy usa `...` como atalho ao fatiar arrays com muitas dimensões; por exemplo, se `x` é um array com quatro dimensões, `x[i, ...]` é um atalho para `x[i, :, :, :,]`.
+As((("ellipsis (&#x2026;)")))((("&#x2026; (ellipsis)"))) reticências—escritas como três pontos finais (`\...`) e não como `…` (Unicode U+2026)&#x2014;são reconhecidas como um símbolo pelo parser do Python. Esse símbolo é um apelido para o objeto `Ellipsis`, a única instância da classe `ellipsis`.footnote:[Não, eu não escrevi ao contrário: o nome da classe `ellipsis` realmente se escreve só com minúsculas, e a instância é um objeto embutido chamado `Ellipsis`, da mesma forma que `bool` é em minúsculas mas suas instâncias são `True` e `False`.]
+Dessa forma, ele pode ser passado como argumento para funções e como parte da especificação de uma fatia, como em `f(a, \..., z)` ou `a[i:\...]`.
+O NumPy usa `\...` como atalho ao fatiar arrays com muitas dimensões; por exemplo, se `x` é um array com quatro dimensões, `x[i, \...]` é um atalho para `x[i, :, :, :,]`.
 Veja  https://fpy.li/2-13["NumPy quickstart"] (EN)
 para saber mais sobre isso.
 
@@ -2094,7 +2094,7 @@ https://fpy.li/pep448[PEP 448—Additional Unpacking Generalizations (_Generaliz
 O Python 3.10 introduziu o _pattern matching_ com `match/case`,
 suportando um tipo de desempacotamento mais poderoso, conhecido como desestruturação.
 
-Fatiamento de sequências é um dos recursos de sintaxe preferidos do Python, e é ainda mais poderoso do que muita gente pensa. Fatiamento multidimensional e a notação de reticências (`...`), como usados no NumPy, podem também ser suportados por sequências definidas pelo usuário.
+Fatiamento de sequências é um dos recursos de sintaxe preferidos do Python, e é ainda mais poderoso do que muita gente pensa. Fatiamento multidimensional e a notação de reticências (`\...`), como usados no NumPy, podem também ser suportados por sequências definidas pelo usuário.
 Atribuir a fatias é uma forma muito expressiva de editar sequências mutáveis.
 
 Concatenação repetida, como em `seq * n`, é conveniente e, tomando cuidado, pode ser usada para inicializar listas de listas contendo itens imutáveis.

--- a/capitulos/cap03.adoc
+++ b/capitulos/cap03.adoc
@@ -531,7 +531,7 @@ Entretanto, lembre-se que `k in my_dict` faz o mesmo trabalho, e é mais rápido
 
 Eu tinha uma razão específica para usar `self.keys()` no método `+__contains__+` do
 <<ex_strkeydict0>>.
-A verificação da chave não-modificada—++key in self.keys()++—é necessária por correção, pois `StrKeyDict0` não obriga todas as chaves no dicionário a serem do tipo `str`.
+A verificação da chave não-modificada `++key in self.keys()++` é necessária por correção, pois `StrKeyDict0` não obriga todas as chaves no dicionário a serem do tipo `str`.
 Nosso único objetivo com esse exemplo simples foi fazer a busca "mais amigável", e não forçar tipos.
 
 [WARNING]
@@ -1052,7 +1052,7 @@ Agora vamos revisar a vasta seleção de operações oferecidas pelos conjuntos.
 ==== Operações de conjuntos
 
 A <<set_uml>> dá((("dictionaries and sets", "set operations", id="DASset03-ops")))((("sets", "set operations", id="Soper03")))((("UML class diagrams", "simplified for MutableSet and superclasses")))
-uma visão geral dos métodos que disponíveis em conjuntos mutáveis e imutáveis. Muitos deles são métodos especiais que sobrecarregam operadores, tais como `&` and `>=`. A <<set_operators_tbl>> mostra os operadores matemáticos de conjuntos que tem operadores ou métodos correspondentes no Python. Note que alguns operadores e métodos realizam mudanças no mesmo lugar sobre o conjunto alvo (por exemplo, `&=`, `difference_update`, etc.). Tais operações não fazem sentido no mundo ideal dos conjuntos matemáticos, e também não são implementadas em `frozenset`.
+uma visão geral dos métodos disponíveis em conjuntos mutáveis e imutáveis. Muitos deles são métodos especiais que sobrecarregam operadores, tais como `&` and `>=`. A <<set_operators_tbl>> mostra os operadores matemáticos de conjuntos que tem operadores ou métodos correspondentes no Python. Note que alguns operadores e métodos realizam mudanças no mesmo lugar sobre o conjunto alvo (por exemplo, `&=`, `difference_update`, etc.). Tais operações não fazem sentido no mundo ideal dos conjuntos matemáticos, e também não são implementadas em `frozenset`.
 
 [role="man-height4"]
 [TIP]
@@ -1110,7 +1110,7 @@ A <<set_comparison_tbl>> lista predicados de conjuntos: operadores e métodos qu
 ||||
 |   e ∈ S   | `e in s`      | `+s.__contains__(e)+` | Elemento `e` é membro de `s`
 ||||
-|   S ⊆ Z   | `s <= z`      |       `+s.__le__(z)+` | `s` é um subconjunto do conjunto `z`
+|   S ⊆ Z   | `s \<= z`      |       `+s.__le__(z)+` | `s` é um subconjunto do conjunto `z`
 |           |               |    `s.issubset(it)` | `s` é um subconjunto do conjunto criado a partir do iterável `it`
 ||||
 |   S ⊂ Z   | `s < z`       |       `+s.__lt__(z)+` | `s` é um subconjunto própriofootnote:[NT: Na teoria dos conjuntos, A é um _subconjunto próprio_ de B se A é subconjunto de B e A é diferente de B.] do conjunto `z`
@@ -1226,7 +1226,7 @@ Dois métodos poderosos disponíveis na maioria dos mapeamentos são `setdefault
 Desde o Python  3.9 também podemos usar o operador `|=` para atualizar uma mapeamento e
 o operador `|` para criar um novo mapeamento a partir a união de dois mapeamentos.
 
-Um gancho elegante na API de mapeamento é o método `+__missing__+`, que permite personalziar o que acontece quando uma chave não é encontrada ao se usar a sintaxe `d[k]` syntax,
+Um gancho elegante na API de mapeamento é o método `+__missing__+`, que permite personalizar o que acontece quando uma chave não é encontrada ao se usar a sintaxe `d[k]` syntax,
 que invoca `+__getitem__+`.
 
 O módulo `collections.abc` oferece as classes base abstratas `Mapping` e `MutableMapping` como interfaces padrão, muito úteis para checagem de tipo durante a execução.
@@ -1288,7 +1288,7 @@ JSON foi proposto como https://fpy.li/3-32["The Fat-Free Alternative to XML" (_A
 e se tornou um imenso sucesso, substituindo o XML em vários contextos.
 Uma sintaxe concisa para listas e dicionários resulta em um excelente formato para troca de dados.
 
-O PHP e o Ruby imitaram a sintaxe de hash do Perl, usando `=>` para ligar chaves a valores.
+O PHP e o Ruby imitaram a sintaxe de hash do Perl, usando `\=>` para ligar chaves a valores.
 O JavaScript usa `:` como o Python. Por que usar dois caracteres, quando um já é legível o bastante?
 
 O JSON veio do JavaScript, mas por acaso também é quase um subconjunto exato da sintaxe do Python.


### PR DESCRIPTION
Principal mudança nessa PR é a correção de alguns caracteres que são transformados em símbolos quando o asciidoctor converte de `.adoc` para `.html`. Segue também outras sugestões.

### Antes:


<img width="573" alt="Screenshot 2023-08-09 at 14 56 21" src="https://github.com/pythonfluente/pythonfluente2e/assets/26190371/545ae29f-cbb1-4f44-9093-bbf9c4d0ff6e">
<img width="573" alt="Screenshot 2023-08-09 at 14 57 26" src="https://github.com/pythonfluente/pythonfluente2e/assets/26190371/d58b1311-7d0e-4866-a13b-b06a195ca2f9">
<img width="573" alt="Screenshot 2023-08-09 at 14 58 07" src="https://github.com/pythonfluente/pythonfluente2e/assets/26190371/bcffede8-d17b-475b-bc10-c9f9b1e9a4d6">
<img width="573" alt="Screenshot 2023-08-09 at 14 58 42" src="https://github.com/pythonfluente/pythonfluente2e/assets/26190371/61e0754e-a7f2-4563-993e-4ad27a5efe3b">
<img width="573" alt="Screenshot 2023-08-09 at 14 58 57" src="https://github.com/pythonfluente/pythonfluente2e/assets/26190371/4c3ea1b7-2f8e-41ee-8f54-cdd07ba2b9f7">

### Depois:
<img width="573" alt="Screenshot 2023-08-09 at 14 59 08" src="https://github.com/pythonfluente/pythonfluente2e/assets/26190371/75baf668-b334-4cc5-9757-07d9e0b5aa41">
<img width="573" alt="Screenshot 2023-08-09 at 14 59 19" src="https://github.com/pythonfluente/pythonfluente2e/assets/26190371/996d64da-601f-415e-8a98-51e67baaffa8">
<img width="573" alt="Screenshot 2023-08-09 at 14 59 39" src="https://github.com/pythonfluente/pythonfluente2e/assets/26190371/f160f77b-e6b3-47c1-8de8-5ffdae69c013">
<img width="573" alt="Screenshot 2023-08-09 at 15 00 00" src="https://github.com/pythonfluente/pythonfluente2e/assets/26190371/6b7104cf-c2fe-4232-aa21-ec3883ee30a8">
<img width="573" alt="Screenshot 2023-08-09 at 15 00 12" src="https://github.com/pythonfluente/pythonfluente2e/assets/26190371/895b22a3-33fc-417c-9f05-be8891692dc2">
