### PR TITLE
Pequeno typo no início do prefácio

### DIFF
--- a/Prefacio.adoc
+++ b/Prefacio.adoc
@@ -16,7 +16,7 @@ __Para Marta, com todo o meu amor.__
 
 [quote, Tim Peters, lendário colaborador do CPython e autor do <em>Zen do Python</em>]
 ____
-Eis um plano: se uma pessa usar um recurso que você não entende, mate-a.
+Eis um plano: se uma pessoa usar um recurso que você não entende, mate-a.
 É mais fácil que aprender algo novo, e em pouco tempo os únicos programadores sobreviventes
 usarão apenas um subconjunto minúsculo e fácil de entender do Python 0.9.6 <piscadela marota>.footnote:[Mensagem para o grupo da Usenet comp.lang.python em 23 de dezembro de 2002: https://fpy.li/p-1["Acrimony in c.l.p"] (EN).]
 ____


### PR DESCRIPTION
Havia um "o" faltante em "pessoa"

@ramalho : Como é meu primeiro PR para o projeto do seu livro, pode me avisar se precisar seguir alguma recomendação especial. Confesso que não li a documentação sobre como contribuir - visto que era apenas um pequeno typo e estou acompanhando um curso no momento.