### PR TITLE
Corrige erro de digitação em `2.6.1`

### DIFF
--- a/capitulos/cap02.adoc
+++ b/capitulos/cap02.adoc
@@ -1021,7 +1021,7 @@ include::code/02-array-seq/lispy/py3.10/lis.py[tags=EVAL_MATCH_BOTTOM]
 <1> Casa se o sujeito for uma sequência de dois itens começando com `'quote'`.
 <2> Casa se o sujeito for uma sequência de quatro itens começando com `'if'`.
 <3> Casa se o sujeito for uma sequência com três ou mais itens começando com `'lambda'`. A guarda assegura que `body` não esteja vazio.
-<4> Casa de o sujeito for uma sequência de três itens começando com `'define'`, seguido de uma instância de `Symbol`.
+<4> Casa se o sujeito for uma sequência de três itens começando com `'define'`, seguido de uma instância de `Symbol`.
 <5> é uma boa prática ter um `case` para capturar todo o resto.
 Neste exemplo, se `exp` não casar com nenhum dos padrões, a expressão está mal-formada, então gera um `SyntaxError`.
 


### PR DESCRIPTION
Pequeno erro de digitação no conteúdo de [Pattern matching com sequências](https://pythonfluente.com/#sequence_patterns_sec)