### PR TITLE
Corrige problema de renderização relacionado ao parsing de `+ ... +`

### DIFF
--- a/capitulos/cap16.adoc
+++ b/capitulos/cap16.adoc
@@ -80,7 +80,7 @@ Vamos começar pelo tópico mais fácil: operadores unários.
 A seção https://docs.python.org/pt-br/3/reference/expressions.html#unary-arithmetic-and-bitwise-operations["6.5. Unary arithmetic and bitwise operations" (_Aritmética unária e operações binárias_)] (EN), de _A Referência da Linguagem Python_, elenca((("operator overloading", "unary operators", id="OOunary16")))((("unary operators", id="unary16"))) três operações unárias, listadas abaixo juntamente com seus métodos especiais associados:
 
 `-`, implementado por `+__neg__+`:: Negativo((("&#x005F;&#x005F;neg&#x005F;&#x005F;"))) aritmético unário. Se `x` é `-2` então `-x == 2`.
-`+`, implementado por `+__pos__+`:: Positivo((("&#x005F;&#x005F;pos&#x005F;&#x005F;"))) aritmético unário. De forma geral, `x == +x`, mas há alguns poucos casos onde isso não é verdadeiro. Veja a seção <<when_plus_x_sec>>, se estiver curioso.
+`{plus}`, implementado por `+__pos__+`:: Positivo((("&#x005F;&#x005F;pos&#x005F;&#x005F;"))) aritmético unário. De forma geral, `x == +x`, mas há alguns poucos casos onde isso não é verdadeiro. Veja a seção <<when_plus_x_sec>>, se estiver curioso.
 `~`, implementado por `+__invert__+`:: Negação((("&#x005F;&#x005F;invert&#x005F;&#x005F;"))) binária, ou inversão binária de um inteiro, definida como `~x == -(x+1)`. Se `x` é `2` então `~x == -3`.footnote:[Veja https://pt.wikipedia.org/wiki/L%C3%B3gica_bin%C3%A1ria#NOT[Lógica Binária - NOT] para uma explicação da negação binária.]
 
 O pass:[<a href="https://docs.python.org/pt-br/3/reference/datamodel.html#object.__neg__">capítulo "Modelo de Dados"</a>] de _A Referência da Linguagem Python_ também inclui a função embutida `abs()` como um operador unário. O método especial associado é `+__abs__+`, como já vimos.


### PR DESCRIPTION
Essa parte estava sendo [renderizada no website](https://pythonfluente.com/#_operadores_un%C3%A1rios) como

```
    `, implementado por `+__pos__
```