### PR TITLE
Typo capítulo 1

### DIFF
--- a/capitulos/cap01.adoc
+++ b/capitulos/cap01.adoc
@@ -377,10 +377,10 @@ Implementamos cinco métodos especiais, além do costumeiro `+__init__+`.
 Veja que nenhum deles é chamado diretamente dentro da classe ou durante seu uso normal, ilustrado pelos doctests.
 Como mencionado antes, o interpretador Python é o único usuário frequente da maioria dos métodos especiais.
 
-O <<ex_vector2d>> implementa dois operadores: `+` e `*`,
+O <<ex_vector2d>> implementa dois operadores: `{plus}` e `*`,
 para demonstrar o uso básico de `+__add__+` e `+__mul__+`.
 No dois casos, os métodos criam e devolvem uma nova instância de `Vector`,
-e não modificam nenhum dos operandos: `+self+` e `other` são apenas lidos.
+e não modificam nenhum dos operandos: `self` e `other` são apenas lidos.
 Esse é o comportamento esperado de operadores infixos: criar novos objetos e não tocar em seus operandos.
 Vou falar muito mais sobre esse tópico no capítulo <<operator_overloading>>.
 


### PR DESCRIPTION
O parse do AsciiDoc ficava confuso depois do `+` e acabava pegando mais texto do que devia