### PR TITLE
Correções de erros de formatação na Seção 2.8

### DIFF
--- a/capitulos/cap02.adoc
+++ b/capitulos/cap02.adoc
@@ -1308,7 +1308,7 @@ mas há detalhes sutis em seu funcionamento, como veremos a seguir.((("", startr
 
 
 === Usando + e * com sequências
-Programadores((("sequences", "using &#x002B; and &#x002A; with", id="Splusast02")))((("&#x002B; operator", id="plusop02")))((("star (&#x002A;) operator", id="starseq02")))((("&#x002A; (star) operator", id="starseq02a")))((("concatenation", id="concat02"))) Python esperam que sequências suportem `+` e `*`. Em geral, os dois operandos de `+` devem ser sequências do mesmo tipo, e nenhum deles é modificado, uma nova sequência daquele mesmo tipo é criada como resultado da concatenação.
+Programadores((("sequences", "using &#x002B; and &#x002A; with", id="Splusast02")))((("&#x002B; operator", id="plusop02")))((("star (&#x002A;) operator", id="starseq02")))((("&#x002A; (star) operator", id="starseq02a")))((("concatenation", id="concat02"))) Python esperam que sequências suportem `\+` e `*`. Em geral, os dois operandos de `+` devem ser sequências do mesmo tipo, e nenhum deles é modificado, uma nova sequência daquele mesmo tipo é criada como resultado da concatenação.
 
 Para concatenar múltiplas cópias da mesma sequência basta multiplicá-la por um inteiro.
 E da mesma forma, uma nova sequência é criada:
@@ -1406,15 +1406,15 @@ Por outro lado, a compreensão de lista no  <<ex_list_of_lists_ok>> equivale ao 
 Se o problema ou a solução mostrados nessa seção não estão claros para você, não se preocupe. O  <<mutability_and_references>> foi escrito para esclarecer a mecânica e os perigos das referências e dos objetos mutáveis.
 ====
 
-Até aqui discutimos o uso dos operadores simples `+` e `+*+` com sequências,
+Até aqui discutimos o uso dos operadores simples `\+` e `\*` com sequências,
 mas existem também os operadores `+=` e `*=`, que produzem resultados muito diferentes, dependendo da mutabilidade da sequência alvo. A próxima seção explica como eles funcionam.
 
 [[aug_assign_seqs]]
 ==== Atribuição aumentada com sequências
 
-Os((("augmented assignment operators", id="augasop02")))((("&#x002B;&#x003D; (addition assignment) operator", id="adassign02")))((("&#x002A;&#x003D; (star equals) operator", id="stareq02")))((("addition assignment (&#x002B;&#x003D;) operator", id="additonassign02"))) operadores de atribuição aumentada `+=` e `++*=++`` se comportam de formas muito diferentes, dependendo do primeiro operando. Para simplificar a discussão, vamos primeiro nos concentrar na adição aumentada (`+=`), mas os conceitos se aplicam a `*=` e a outros operadores de atribuição aumentada.
+Os((("augmented assignment operators", id="augasop02")))((("&#x002B;&#x003D; (addition assignment) operator", id="adassign02")))((("&#x002A;&#x003D; (star equals) operator", id="stareq02")))((("addition assignment (&#x002B;&#x003D;) operator", id="additonassign02"))) operadores de atribuição aumentada `\+=` e `\*=` se comportam de formas muito diferentes, dependendo do primeiro operando. Para simplificar a discussão, vamos primeiro nos concentrar na adição aumentada (`+=`), mas os conceitos se aplicam a `*=` e a outros operadores de atribuição aumentada. 
 
-O((("&#x005F;&#x005F;iadd&#x005F;&#x005F;"))) método especial que faz `+=` funcionar é `+__iadd__+` (significando "in-place addition", _adição no mesmo lugar_).
+O((("&#x005F;&#x005F;iadd&#x005F;&#x005F;"))) método especial que faz `+=` funcionar é `\__iadd_\_` (significando "in-place addition", _adição no mesmo lugar_).
 
 Entretanto, se `+__iadd__+` não estiver implementado, o Python chama `+__add__+` como fallback.
 Considere essa expressão simples:


### PR DESCRIPTION
Este PR contém as correções necessárias de alguns erros de formatações descritos na issue #69 .

Agradeço muito pela issue bem descrita, @luxedo , ela foi um grande facilitador para a correção. 
Também gostaria de agradecer ao @ramalho por este livro, é incrível encontrar um conteúdo tão bom e aprofundado sobre python em pt-br, muitíssimo obrigado <3!

Descrevendo a correção, as alterações foram feitos na [seção 2.8 do livro](https://pythonfluente.com/#_usando_e_com_sequências).

Afim de facilitar a revisão deste PR, irei adicionar algumas imagens com a versão que está no site do projeto e comparar com o arquivo html criado após as correções.



## [Parágrafo inicial da seção 3.8](https://pythonfluente.com/#_usando_e_com_sequências)

### Antes
![image](https://github.com/pythonfluente/pythonfluente2e/assets/62259205/0881b452-a80f-4d88-a5fd-aed8f60e762a)

### Depois
![image](https://github.com/pythonfluente/pythonfluente2e/assets/62259205/7e9be1ba-66f6-43cf-8a72-0615880aa65a)

## [Último parágrafo seção 3.8.1](https://pythonfluente.com/#_criando_uma_lista_de_listas)

### Antes
![image](https://github.com/pythonfluente/pythonfluente2e/assets/62259205/0d00243c-cd5f-49c1-adca-9b44a90e5d11)

### Depois
![image](https://github.com/pythonfluente/pythonfluente2e/assets/62259205/b925114c-17a7-4e3c-aa72-8bf34374e9a2)


## [2 primeiros parágrafos da seção 3.8.2](https://pythonfluente.com/#aug_assign_seqs)

### Antes
![image](https://github.com/pythonfluente/pythonfluente2e/assets/62259205/9042f6d4-0da9-448a-a307-3dc87df86a03)

### Depois
![image](https://github.com/pythonfluente/pythonfluente2e/assets/62259205/4876f39a-beae-44c9-81c0-ddbc5c5de38a)
