### PR TITLE
GitHub Actions: Lint Python code only for SyntaxErrors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+# This Action uses minimal steps to run in ~5 seconds to rapidly:
+# lint Python code using ruff which provides intuitive GitHub Annotations to contributors.
+# https://docs.astral.sh/ruff/
+
+name: ci
+on:
+  push:
+    # branches: [main]
+  pull_request:
+    # branches: [main]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: astral-sh/ruff-action@v3
+      with:
+        args: check --ignore=ALL  # Turn off 800+ lint rules to only look for Python SyntaxErrors.

--- a/capitulos/code/11-pythonic-obj/private/expose.py
+++ b/capitulos/code/11-pythonic-obj/private/expose.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env jython
 # NOTE: Jython is still Python 2.7 in late2020
 
+from __future__ import print_function
+
 import Confidential
 
 message = Confidential('top secret text')
 secret_field = Confidential.getDeclaredField('secret')
 secret_field.setAccessible(True)  # break the lock!
-print 'message.secret =', secret_field.get(message)
+print('message.secret =', secret_field.get(message))

--- a/capitulos/code/11-pythonic-obj/private/leakprivate.py
+++ b/capitulos/code/11-pythonic-obj/private/leakprivate.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env jython
 # NOTE: Jython is still Python 2.7 in late2020
 
+from __future__ import print_function
+
 from java.lang.reflect import Modifier
 import Confidential
 
@@ -10,5 +12,5 @@ for field in fields:
     # list private fields only
     if Modifier.isPrivate(field.getModifiers()):
         field.setAccessible(True) # break the lock
-        print 'field:', field
-        print '\t', field.getName(), '=', field.get(message)
+        print('field:', field)
+        print('\t', field.getName(), '=', field.get(message))

--- a/capitulos/code/11-pythonic-obj/private/no_respect.py
+++ b/capitulos/code/11-pythonic-obj/private/no_respect.py
@@ -9,6 +9,7 @@ python.security.respectJavaAccessibility = true
 Set this to false and Jython provides access to non-public
 fields, methods, and constructors of Java objects.
 """
+from __future__ import print_function
 
 import Confidential
 
@@ -16,4 +17,4 @@ message = Confidential('top secret text')
 for name in dir(message):
     attr = getattr(message, name)
     if not callable(attr):  # non-methods only
-        print name + '\t=', attr
+        print(name + '\t=', attr)


### PR DESCRIPTION
Just in case Jython ever gets to Python 3...
* https://github.com/jython/jython/tree/main -- `main` (not default `master`) branch are the Python 3 efforts.

Turn off 800+ lint rules to only look for Python SyntaxErrors.
* https://docs.astral.sh/ruff
* Test results: https://github.com/cclauss/pythonfluente2e/actions
```
capitulos/code/11-pythonic-obj/private/expose.py:9:7:
    SyntaxError: Simple statements must be separated by newlines or semicolons
capitulos/code/11-pythonic-obj/private/leakprivate.py:13:15:
    SyntaxError: Simple statements must be separated by newlines or semicolons
capitulos/code/11-pythonic-obj/private/leakprivate.py:14:15:
    SyntaxError: Simple statements must be separated by newlines or semicolons
capitulos/code/11-pythonic-obj/private/no_respect.py:19:15:
    SyntaxError: Simple statements must be separated by newlines or semicolons
```

% `uv tool run --python=3.12 --from=future futurize --stage1 --write capitulos/code/11-pythonic-obj/private`