### PR TITLE
[ERRATA] Cap. 4, gramática e outros

### DIFF
--- a/vol1/cap04.adoc
+++ b/vol1/cap04.adoc
@@ -181,11 +181,11 @@ bytearray(b'\xa9')
 [WARNING]
 ====
 O fato de `my_bytes[0]` obter um `int` mas `my_bytes[:1]` devolver uma sequência de `bytes` de tamanho 1
-só é surpreeendente porque estamos acostumados com o tipo `str` de Python, onde `s[0] == s[:1]`.
+só é surpreendente porque estamos acostumados com o tipo `str` de Python, onde `s[0] == s[:1]`.
 Para todos os outros tipos de sequência no Python, um item não é o mesmo que uma fatia de tamanho 1.
 ====
 
-Apesar de sequências binárias serem na verdade sequências de inteiros,
+Apesar de sequências binárias serem, na verdade, sequências de inteiros,
 sua notação literal reflete o fato delas frequentemente embutirem texto ASCII.
 Assim, quatro formas diferentes de apresentação são utilizadas, dependendo do valor de cada byte:
 
@@ -196,7 +196,7 @@ são usadas as sequências de escape `\t`, `\n`, `\r`, e `\\`.
 a sequência inteira é delimitada com `'`, e qualquer `'` dentro da sequência é precedida do caractere de escape,
 assim `\'`.footnote:[Trívia: O caractere ASCII "aspas simples",
 que por default Python usa como delimitador de strings,
-na verdade se chama APOSTROPHE no padrão Unicode.
+na verdade, se chama APOSTROPHE no padrão Unicode.
 As aspas simples reais são assimétricas: a da esquerda é U+2018 e a da direita U+2019.]
 * Para qualquer outro valor do byte, é usada uma sequência de escape hexadecimal (por exemplo, `\x00` é o byte nulo).
 
@@ -215,7 +215,7 @@ causando muitas dores de cabeça nos desenvolvedores que lidam com dados binári
 A decisão está documentada na
 «PEP 461--Adding % formatting to bytes and bytearray (_Acrescentando formatação com % a bytes e bytearray_)» [.small]#&#91;fpy.li/pep461&#93;#. (EN)]
 
-As sequências binárias tem um método de classe que `str` não possui, chamado `fromhex`,
+As sequências binárias têm um método de classe que `str` não possui, chamado `fromhex`,
 que cria uma sequência binária a partir da análise de pares de dígitos hexadecimais,
 separados opcionalmente por espaços:
 
@@ -229,14 +229,14 @@ As outras formas de criar instâncias de `bytes` ou `bytearray` são chamadas a 
 
 * Uma `str` e um argumento nomeado `encoding`
 * Um iterável que forneça itens com valores entre 0 e 255
-* Um objeto que implemente o protocolo de buffer (por exemplo `bytes`, `bytearray`, `memoryview`,
+* Um objeto que implemente o protocolo de buffer (por exemplo, `bytes`, `bytearray`, `memoryview`,
 `array.array`), que copia os bytes do objeto fonte para a recém-criada sequência binária
 
 [WARNING]
 ====
 Até Python 3.5, era possível chamar `bytes` ou `bytearray` com um único inteiro,
 para criar uma sequência daquele tamanho inicializada com bytes nulos.
-Essa assinatura for descontinuada no Python 3.5 e removida no Python 3.6.
+Essa assinatura foi descontinuada no Python 3.5 e removida no Python 3.6.
 Veja a https://fpy.li/pep467[PEP 467--Minor API improvements for binary sequences
 (_Pequenas melhorias na API para sequências binárias_) (EN)].
 ====
@@ -334,7 +334,7 @@ A UTF-16((("UCS-2 encoding")))((("emojis", "UCS-2 versus UTF-16 encoding")))
 sucedeu a codificação de 16 bits original do Unicode 1.0—a UCS-2—há muito tempo, em 1996.
 Mas a UCS-2 obsoleta ainda é usada em muitos sistemas, apesar de ter sido descontinuada
 por suportar apenas pontos de código até U+FFFF.
-Em 2021, mas de 57% dos pontos de código alocados ficam acima de U+FFFF,
+Em 2021, mais de 57% dos pontos de código alocados ficam acima de U+FFFF,
 incluindo os importantíssimos emojis.
 ====
 
@@ -433,7 +433,7 @@ Se for, você deve ser capaz de codificá-lo para bytes em qualquer codificaçã
 
 Nem((("UnicodeDecodeError"))) todo byte contém um caractere ASCII válido,
 e nem toda sequência de bytes é um texto corretamente codificado em UTF-8 ou UTF-16;
-assim, se você presumir uma dessas codificações ao converter um sequência binária para texto,
+assim, se você presumir uma dessas codificações ao converter uma sequência binária para texto,
 pode receber um `UnicodeDecodeError`, se bytes inesperados forem encontrados.
 
 Por outro lado, várias codificações de 8 bits antigas, como a `'cp1252'`, a `'iso8859_1'` e a `'koi8_r'`
@@ -473,7 +473,7 @@ invalid continuation byte
 <2> Decodificar com Windows 1252 funciona, pois esse codec é um superconjunto de `latin1`.
 <3> ISO-8859-7 foi projetado para a língua grega, então o byte `'\xe9'` é interpretado incorretamente,
 mas nenhum erro é gerado.
-<4> KOI8-R é foi projetado para o russo.
+<4> KOI8-R foi projetado para o russo.
 Agora `'\xe9'` significa a letra "И" do alfabeto cirílico.
 <5> O codec `'utf_8'` detecta que `octets` não é UTF-8 válido, e gera um `UnicodeDecodeError`.
 <6> Usando `'replace'` para tratamento de erro, o `\xe9` é substituído por "�"
@@ -548,7 +548,7 @@ ou mesmo uma sequência não-aleatória de bytes de uma codificação diferente 
 seja acidentalmente decodificada como lixo no UTF-8, ao invés de gerar um `UnicodeDecodeError`.
 
 As razões para isso são que as sequências de escape do UTF-8 nunca usam caracteres ASCII,
-e tais sequências de escape tem padrões de bits que tornam muito difícil que dados aleatórioas sejam UTF-8 válido por acidente.
+e tais sequências de escape tem padrões de bits que tornam muito difícil que dados aleatórios sejam UTF-8 válido por acidente.
 
 Portanto, se você consegue decodificar alguns bytes contendo códigos > 127 como UTF-8,
 a maior probabilidade é de sequência estar em UTF-8.
@@ -623,7 +623,7 @@ e então o codec sabe qual ordenação de bytes usar.
 
 Há uma variante do UTF-16--o UTF-16LE--que é explicitamente _little-endian_,
 e outra que é explicitamente _big-endian_, o UTF-16BE.
-Se você usá-los, um BOM não será gerado:
+Se você os usar, um BOM não será gerado:
 
 [source,pycon]
 ----
@@ -663,7 +663,7 @@ Caleb Hattingh—um dos revisores técnicos—sugere sempre usar o codec UTF-8-S
 Isso é inofensivo, pois o UTF-8-SIG lê corretamente arquivos com ou sem um BOM, e não devolve o BOM propriamente dito.
 Para escrever arquivos, recomendo usar UTF-8, para interoperabilidade integral.
 Por exemplo, scripts Python podem ser tornados executáveis em sistemas Unix,
-se começarem com o comentário: `#!/usr/bin/env python3`.
+se começarem com o comentário: `\#!/usr/bin/env python3`.
 Os dois primeiros bytes do arquivo precisam ser `+b'#!'+` para isso funcionar, mas o BOM quebra essa convenção.
 Se você tem o requerimento específico de exportar dados para aplicativos que precisam do BOM,
 use o UTF-8-SIG, mas esteja ciente do que diz a
@@ -783,7 +783,7 @@ com a codificação configurada para um default do locale.
 <6> Na codificação `cp1252` do Windows, o byte 0xc3 é um "Ã" (A maiúsculo com til),
 e 0xa9 é o símbolo de copyright.
 <7> Abrindo o mesmo arquivo com a codificação correta.
-<8> O resultado esperado: os mesmo quatro caracteres Unicode para `'café'`.
+<8> O resultado esperado: os mesmos quatro caracteres Unicode para `'café'`.
 <9> A flag `'rb'` abre um arquivo para leitura em modo binário.
 <10> O objeto devolvido é um `BufferedReader`, e não um `TextIOWrapper`.
 <11> Ler do arquivo obtém bytes, como esperado.
@@ -925,9 +925,9 @@ include::../code/04-text-byte/stdout_check.py[]
 O <<ex_stdout_check>> mostra o resultado de uma chamada a `sys.stdout.isatty()`,
 o valor de `sys.stdout.encoding`, e esses três caracteres:
 
-* `'…'` `HORIZONTAL ELLIPSIS`—existe no CP 1252 mas não no CP 437.
-* `'∞'` `INFINITY`—existe no CP 437 mas não no CP 1252.
-* `'㊷'` `CIRCLED NUMBER FORTY TWO`—não existe nem no CP 1252 nem no CP 437.
+* `'…'` `HORIZONTAL ELLIPSIS`—existe no CP 1252, mas não no CP 437.
+* `'∞'` `INFINITY`—existe no CP 437, mas não no CP 1252.
+* `'㊷'` `CIRCLED NUMBER FORTY TWO`—não existe nem no CP, 1252 nem no CP 437.
 
 Quando executo _stdout_check.py_ no PowerShell ou no _cmd.exe_, funciona como visto na <<fig_stdout_check>>.
 
@@ -1195,7 +1195,7 @@ A operação é suportada pelo método `str.casefold()`.
 Para qualquer string `s` contendo apenas caracteres `latin1`, `s.casefold()`
 produz o mesmo resultado de `s.lower()`, com apenas duas exceções—o símbolo de micro, `'µ'`,
 é trocado pela letra grega mu minúscula (que é exatamente igual na maioria das fontes)
-e a letra alemã _Eszett_ (ß), também chamada "s agudo" (_scharfes S_) se torna "ss":
+e a letra alemã _Eszett_ (ß), também chamada "s agudo" (_scharfes S_), se torna "ss":
 
 [source, python]
 ----
@@ -1247,7 +1247,7 @@ include::../code/04-text-byte/normeq.py[]
 
 Além da normalização e do _case folding_ do Unicode—ambos partes desse padrão—algumas
 vezes faz sentido aplicar transformações mais profundas,
-como por exemplo mudar `'café'` para `'cafe'`.
+como, por exemplo, mudar `'café'` para `'cafe'`.
 Vamos ver quando e como na próxima seção.
 
 
@@ -1398,7 +1398,7 @@ ordena sequências de qualquer tipo comparando um por um os itens em cada sequê
 Para strings, isso significa comparar pontos de código.
 Infelizmente, isso produz resultados inaceitáveis para qualquer um que use caracteres não-ASCII.
 
-Considere ordenar uma lista de frutas cultivadas no Brazil:
+Considere ordenar uma lista de frutas cultivadas no Brasil:
 
 [source, python]
 ----
@@ -1413,7 +1413,7 @@ acentos e cedilhas raramente fazem diferença na ordenação.footnote:[Sinais
 diacríticos afetam a ordenação apenas nos raros casos em que eles são
 a única diferença entre duas palavras—nesse caso,
 a palavra com o sinal diacrítico é colocada após a palavra sem o sinal na ordenação.]
-Então "cajá" é lido como "caja," e deve vir antes de "caju."
+Então "cajá" é lido como "caja" e deve vir antes de "caju".
 
 A lista `fruits` ordenada deveria ser:
 
@@ -1431,7 +1431,7 @@ e rezar para que o SO o suporte.
 A sequência de comando no <<ex_locale_sort>> pode funcionar para você.
 
 [[ex_locale_sort]]
-._locale_sort.py_: Usando a função `locale.strxfrm` como chave de ornenamento
+._locale_sort.py_: Usando a função `locale.strxfrm` como chave de ordenamento
 ====
 [source, python]
 ----
@@ -1455,7 +1455,7 @@ antes de usar `locale.strxfrm` como a chave de ordenação.
 Porém, aqui vão algumas ressalvas:
 
 * Como as configurações de _locale_ são globais, não é recomendado chamar `setlocale` em uma biblioteca.
-Sua aplicação ou framework deveria definir o _locale_ no início do processo, e não mudá-lo mais depois disso.
+Sua aplicação ou framework deveria definir o _locale_ no início do processo, e não o mudar mais depois disso.
 * O _locale_ desejado deve estar instalado no SO,
 caso contrário `setlocale` gera uma exceção de `locale.Error: unsupported locale setting`.
 * Você tem que saber como escrever corretamente o nome do locale.
@@ -1561,7 +1561,7 @@ id="Cfinduni04"))) módulo `unicodedata` tem funções para obter os metadados d
 `unicodedata.name()`, que devolve o nome oficial do caractere no padrão.
 A <<unicodedata_name_fig>> demonstra essa função.footnote:[Aquilo é uma
 imagem—não uma listagem de código—porque, no momento em que esse capítulo foi escrito,
-os emojis não tem um bom suporte no sistema de publicação digital da O'Reilly.]
+os emojis não têm um bom suporte no sistema de publicação digital da O'Reilly.]
 
 [[unicodedata_name_fig]]
 .Explorando `unicodedata.name()` no console de Python.
@@ -1722,7 +1722,7 @@ Para expressões regulares `str`, há uma marcação `re.ASCII`,
 que faz `\w`, `\W`, `\b`, `\B`, `\d`, `\D`, `\s`, e `\S`
 casarem apenas com ASCII.
 Veja a
-«documentaçào do módulo `re`» [.small]#&#91;fpy.li/3j&#93;# para mais detalhes.
+«documentação do módulo `re`» [.small]#&#91;fpy.li/3j&#93;# para mais detalhes.
 
 Outro módulo importante é o `os`.
 
@@ -1746,7 +1746,7 @@ Mas se você precisa lidar com (e provavelmente corrigir) nomes de arquivo que
 não podem ser processados daquela forma,
 você pode passar argumentos `bytes` para as funções de `os`, e receber `bytes` de volta.
 Esse recurso permite que você processe qualquer nome de arquivo ou caminho,
-independende de quantos gremlins encontrar.
+independente de quantos gremlins encontrar.
 Veja o <<ex_listdir1>>.
 
 [[ex_listdir1]]
@@ -1790,7 +1790,7 @@ seguida por abordagens para prevenir ou lidar com os abomináveis
 causados pela codificação errada em arquivos de código-fonte de Python.
 
 A seguir consideramos a teoria e a prática de detecção de codificação na ausência de metadados:
-em teoria, não pode ser feita, mas na prática o pacote Chardet
+em teoria, não pode ser feita, mas, na prática, o pacote Chardet
 consegue realizar esse feito para uma grande quantidade de codificações populares.
 Marcadores de ordem de bytes foram apresentados como a única dica de codificação
 encontrada em arquivos UTF-16 e UTF-32--algumas vezes também em arquivos UTF-8.
@@ -1858,7 +1858,7 @@ um valioso estudo de caso, dado que a mudança do antigo tipo `str` para o novo 
 é a causa da maioria das dores da migração,
 e esta é uma preocupação central em uma biblioteca projetada para detectar codificações.
 
-Se você conhece Python 2 mas é novo no Python 3, o artigo
+Se você conhece Python 2, mas é novo no Python 3, o artigo
 «"What’s New in Python 3.0" (_O quê há de novo no Python 3.0_)» [.small]#&#91;fpy.li/4-36&#93;# (EN),
 de Guido van Rossum, tem 15 pontos resumindo as mudanças, com vários links.
 Guido inicia com uma afirmação brutal:
@@ -1953,7 +1953,7 @@ permite identificadores não-ASCII no código-fonte:
 ----
 
 Algumas pessoas não gostam dessa ideia.
-O argumento mais comum é que se limitar aos caracteres ASCII torna a leitura e a edição so código mais fácil para todo mundo.
+O argumento mais comum é que se limitar aos caracteres ASCII torna a leitura e a edição do código mais fácil para todo mundo.
 Esse argumento erra o alvo: você quer que seu código-fonte seja legível e editável pela audiência pretendida,
 e isso pode não ser "todo mundo".
 Se o código pertence a uma corporação multinacional, ou se é um código aberto e você deseja contribuidores de todo o mundo,
@@ -1982,14 +1982,14 @@ Para((("Soapbox sidebars", "plain text"))) qualquer um que lide diariamente com 
 
 [quote]
 ____
-Texto codificado por computador que consiste apenas de uma sequência de pontos de código de um dado padrão,
+Texto codificado por computador que consiste apenas em uma sequência de pontos de código de um dado padrão,
 sem qualquer outra informação estrutural ou de formatação.
 ____
 
 Essa definição começa muito bem, mas não concordo com a parte após a vírgula.
 HTML é um ótimo exemplo de um formato de texto puro que inclui informação estrutural e de formatação.
 Mas ele ainda é texto puro, porque cada byte em um arquivo desse tipo está lá para representar um caractere de texto,
-em geral usando UTF-8.
+em geral, usando UTF-8.
 Não há bytes com significado não-textual,
 como você encontra em documentos _.png_ ou _.xls_,
 onde a maioria dos bytes representa valores binários compactos,
@@ -2012,7 +2012,7 @@ muito bem—incluindo os caracteres japoneses para a palavra "mojibake": 文字�
 
 
 [role="soapbox-title"]
-*Como os ponto de código numa str são representados na memória?*
+*Como os pontos de código numa str são representados na memória?*
 
 A((("Soapbox sidebars", "code points")))((("code points"))) documentação oficial de Python
 evita falar sobre como os pontos de código de uma `str` são armazenados na memória.
@@ -2029,7 +2029,7 @@ o interpretador verifica os caracteres no objeto,
 e escolhe o layout de memória mais econômico que seja adequado para aquela `str` em particular:
 se existirem apenas caracteres na faixa `latin1`, aquela `str` vai usar apenas um byte por ponto de código.
 Caso contrário, podem ser usados dois ou quatro bytes por ponto de código, dependendo da `str`.
-Isso é uma simplificação; para saber todos os detalhes, dê uma olhada an
+Isso é uma simplificação; para saber todos os detalhes, dê uma olhada na
 «PEP 393--Flexible String Representation (_Representação Flexível de Strings_)» [.small]#&#91;fpy.li/pep393&#93;# (EN).
 
 A representação flexível de strings é similar à forma como o tipo `int` funciona no Python 3:


### PR DESCRIPTION
Corrige erros básicos do cap. 4 conforme https://github.com/pythonfluente/pythonfluente2e/issues/157

Closes #157