### PR TITLE
Gerar epub dos novos volumes 1-3 2026

### DIFF
--- a/gerar-epub.md
+++ b/gerar-epub.md
@@ -38,8 +38,18 @@ cd pythonfluente2e
 
 Na raiz do repositório recém clonado, iremos executar um container que irá instalar as dependências para gerar o livro, e gerar o `.epub` na mesma raiz. Basta executar o seguinte comando:
 
+Como a versão 2026 do livro foi divida em 3 partes, iremos executar um comando para cada volume, gerando assim o `.epub` respectivo.
+Basta executar os seguintes comandos:
+
 ```bash
-docker run -it --rm -v .:/book ruby sh -c "gem install asciidoctor-epub3 && asciidoctor-epub3 /book/Livro.adoc -o '/book/Python Fluente, Segunda Edição (2023).epub' 2> /dev/null"
+# Volume 1
+docker run -it --rm -v .:/book ruby sh -c "gem install asciidoctor-epub3 && asciidoctor-epub3 /book/vol1/vol1-cor.adoc -o '/book/Python Fluente, Segunda Edição (2026), Volume 1 dados + funções.epub' 2> /dev/null"
+
+# Volume 2
+docker run -it --rm -v .:/book ruby sh -c "gem install asciidoctor-epub3 && asciidoctor-epub3 /book/vol2/vol2-cor.adoc -o '/book/Python Fluente, Segunda Edição (2026), Volume 2 classes + protocolos.epub' 2> /dev/null"
+
+# Volume 3
+docker run -it --rm -v .:/book ruby sh -c "gem install asciidoctor-epub3 && asciidoctor-epub3 /book/vol3/vol3-cor.adoc -o '/book/Python Fluente, Segunda Edição (2026), Volume 3 controle + metaprogramação.epub' 2> /dev/null"
 ```
 
 Neste comando:
@@ -47,6 +57,6 @@ Neste comando:
 - `-it`: Permite entrar no modo iterativo.
 - `--rm`: Remove o container após a saída.
 - `-v .:/book`: Monta o volume com o caminho da pasta raiz no container na em /book.
-- `sh -c "gem install asciidoctor-epub3 && asciidoctor-epub3 /book/Livro.adoc -o '/book/Python Fluente, Segunda Edição (2023).epub' 2> /dev/null"`: Executa o comando especificado dentro do container. O comando faz a instalação do asciidoctor-epub3 dentro do container e realiza o build do livro.
+- `sh -c "gem install asciidoctor-epub3 && asciidoctor-epub3 /book/<vol>.adoc -o '/book/Python Fluente, Segunda Edição.epub' 2> /dev/null"`: Executa o comando especificado dentro do container. O comando faz a instalação do asciidoctor-epub3 dentro do container e realiza o build do livro.
 
 Após isso o container irá executar e salvar automaticamente o livro `.epub` em sua máquina. Basta agora enviar o arquivo para o seu leitor de e-books.


### PR DESCRIPTION
Estava gerando os epubs locais aqui para acompanhar a leitura no celular, mas percebi que os comandos estão apontando para o volume 2023 antigo, como `Livro.adoc` ao invés dos volumes 1,2 e 3.

Deixei o mesmo padrão, por mais que crie 3 containers diferentes, mas pelo menos a pessoa pode escolher qual volume gerar antes.

Obrigado mais um vez pelo livro <3 